### PR TITLE
Fix issues on cocalc

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -17,6 +17,8 @@ dependencies:
   - surface-dynamics>=0.4.7
   - jupytext
   - ruamel.yaml
+  - three.js
+  - tachyon
   - pip
   - pip:
     - flipper

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+python -c 'import cppyy'


### PR DESCRIPTION
this addresses most of #2 except for:

* three.js plots still don't work. Is this a problem in general on cocalc?
* I don't understand why the segfault is happening. It might be due to the missing precompiled headers. I would like to try once this has been merged and redeployed.